### PR TITLE
Add styled components theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^9.29.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/styled-components": "^5.1.34",
         "@vitejs/plugin-react": "^4.6.0",
         "eslint": "^9.29.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1379,6 +1380,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1404,6 +1416,18 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/stylis": {
@@ -2110,6 +2134,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2530,6 +2564,13 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@eslint/js": "^9.29.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react": "^4.6.0",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,20 @@
+import styled from 'styled-components';
+
+const StyledButton = styled.button`
+    padding: 0.6em 1.2em;
+    border-radius: 8px;
+    border: none;
+    background-color: ${({ theme }) => theme.colors.accent};
+    color: ${({ theme }) => theme.colors.text};
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.2s;
+
+    &:hover {
+        background-color: ${({ theme }) => theme.colors.accentHover};
+    }
+`;
+
 export const Button = ({ children, ...props }: any) => (
-    <button {...props} className="bg-blue-600 text-white px-4 py-2 rounded">
-    {children}
-    </button>
+    <StyledButton {...props}>{children}</StyledButton>
 );

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,6 +1,23 @@
+import styled from 'styled-components';
+
+const Label = styled.label`
+    display: block;
+    margin-bottom: 1rem;
+    color: ${({ theme }) => theme.colors.text};
+`;
+
+const StyledInput = styled.input`
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #444;
+    border-radius: 4px;
+    background-color: ${({ theme }) => theme.colors.surface};
+    color: ${({ theme }) => theme.colors.text};
+`;
+
 export const Input = ({ label, ...props }: any) => (
-    <label>
+    <Label>
         <div>{label}</div>
-        <input {...props} className="border p-2 rounded w-full" />
-    </label>
+        <StyledInput {...props} />
+    </Label>
 );

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -1,0 +1,16 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const GlobalStyle = createGlobalStyle`
+  body {
+    margin: 0;
+    padding: 0;
+    background-color: ${({ theme }) => theme.colors.background};
+    color: ${({ theme }) => theme.colors.text};
+    font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+    min-height: 100vh;
+  }
+  a {
+    color: ${({ theme }) => theme.colors.accent};
+    text-decoration: none;
+  }
+`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import {App} from "./App";
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import { App } from './App';
+import { GlobalStyle } from './globalStyles';
+import { theme } from './theme';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <ThemeProvider theme={theme}>
+            <GlobalStyle />
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </ThemeProvider>
     </React.StrictMode>
 );

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,27 @@
 import { useEffect, useState } from 'react';
 import { fetchMe } from '../services/authService';
-import {getFileDownloadUrl, getFiles} from "../services/filesService";
+import { getFileDownloadUrl, getFiles } from '../services/filesService';
+import styled from 'styled-components';
+import { Button } from '../components/Button';
+
+const Wrapper = styled.div`
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 2rem;
+    background-color: ${({ theme }) => theme.colors.surface};
+    border-radius: 8px;
+`;
+
+const FilesList = styled.ul`
+    list-style: none;
+    padding: 0;
+`;
+
+const FileItem = styled.li`
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+`;
 
 export const DashboardPage = () => {
     const [user, setUser] = useState<any>(null);
@@ -58,19 +79,19 @@ export const DashboardPage = () => {
 
 
     return (
-        <div>
+        <Wrapper>
             Добро пожаловать в файловый менеджер{user ? `, ${user.email}` : ''}
             <h2>Ваши файлы:</h2>
-            <ul>
+            <FilesList>
                 {files.map((file) => (
-                    <li key={file.fileId}>
-                        {file.name}{' '}
-                        <button onClick={() => downloadFile(file.fileId, file.name)}>
+                    <FileItem key={file.fileId}>
+                        {file.name}
+                        <Button onClick={() => downloadFile(file.fileId, file.name)}>
                             Скачать
-                        </button>
-                    </li>
+                        </Button>
+                    </FileItem>
                 ))}
-            </ul>
-        </div>
+            </FilesList>
+        </Wrapper>
     );
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,6 +4,21 @@ import { saveTokens } from '../utils/tokenStorage';
 import { login } from '../services/authService';
 import { Input } from '../components/Input';
 import { Button } from '../components/Button';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+    max-width: 400px;
+    margin: 4rem auto;
+    padding: 2rem;
+    background-color: ${({ theme }) => theme.colors.surface};
+    border-radius: 8px;
+`;
+
+const Form = styled.form`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
 
 export const LoginPage = () => {
     const [email, setEmail] = useState('');
@@ -22,10 +37,12 @@ export const LoginPage = () => {
     };
 
     return (
-        <form onSubmit={handleSubmit}>
-            <Input label="Email" value={email} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)} />
-            <Input label="Пароль" type="password" value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)} />
-            <Button type="submit">Войти</Button>
-        </form>
+        <Wrapper>
+            <Form onSubmit={handleSubmit}>
+                <Input label="Email" value={email} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)} />
+                <Input label="Пароль" type="password" value={password} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)} />
+                <Button type="submit">Войти</Button>
+            </Form>
+        </Wrapper>
     );
 };

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,13 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    colors: {
+      background: string;
+      surface: string;
+      text: string;
+      accent: string;
+      accentHover: string;
+    };
+  }
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,11 @@
+import { DefaultTheme } from 'styled-components';
+
+export const theme: DefaultTheme = {
+  colors: {
+    background: '#1a1a1a',
+    surface: '#242424',
+    text: '#ffffff',
+    accent: '#646cff',
+    accentHover: '#535bf2',
+  },
+};


### PR DESCRIPTION
## Summary
- create styled-components design system with dark theme and accent color
- apply ThemeProvider and global styles
- convert Input and Button to styled components
- restyle Login and Dashboard pages

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68674c8b38148320a96cfd3dd621c4ff